### PR TITLE
chore(ci): configure a github action to lint files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - '7.4'
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: firehed/lint-php-action@v1


### PR DESCRIPTION
Configure a github action to check (at least) that the syntax is valid for supported PHP versions